### PR TITLE
Honour time revamp

### DIFF
--- a/technology-principles.md
+++ b/technology-principles.md
@@ -40,10 +40,10 @@ We've got a [big mission](https://bench.co/go/culture/). To get there, we all ne
 Time is the most precious resource we have. This applies at the organizational level and the individual level. By being intentional with the time we assign to our activities, we create an environment where creativity and ingenuity are the drivers of our success, not the time we spend working. This is how we get to be ferociously effective as an organization while also living rich, sustainable lifestyles as individuals.
 
 *Supporting Principles:*
-- We set deadlines to push ourselves to be creative in solving problems.
-- Overtime is cheating: Working extra hours short-circuits the time constraint that we've set for ourselves, keeping us from being creative.
-- Learning and doing are not separate endeavors. Within the time we allocate to a problem, we must account for both the need to deliver a solution and the need to properly learn _how_ to deliver it.
-- If we never exceed a timeline, we’ll never know how fast we can actually go.
-- If we consistently exceed timelines, we’ll lose the trust of our colleagues and customers.
-- Time spent _not working at all_ makes us more effective during the time we spend working.
-- A timeline is most motivating when each person doing the work has personally committed to it.
+- We limit the time we spend on a problem to push ourselves to be creative in solving it.
+- Time spent _doing_ must be balanced by time spent _learning_.
+- If commitments don't have a "by when" date, they won't happen.
+- The most effective commitments are those made by the individuals doing the work.
+- If we never miss the dates we commit to, we’ll never know how fast we can go.
+- If we consistently miss the dates we commit to, no one will trust us.
+- Overtime is cheating—working extra hours is just a sneaky way of missing a date we've committed to.

--- a/technology-principles.md
+++ b/technology-principles.md
@@ -42,8 +42,8 @@ Time is the most precious resource we have. This applies at the organizational l
 *Supporting Principles:*
 - We limit the time we spend on a problem to push ourselves to be creative in solving it.
 - Time spent _doing_ must be balanced by time spent _learning_.
-- If commitments don't have a "by when" date, they won't happen.
 - The most effective commitments are those made by the individuals doing the work.
-- If we never miss the dates we commit to, we’ll never know how fast we can go.
+- If commitments don't have a "by when" date, they won't happen.
+- If we never miss a date we've committed to, we’ll never know how fast we can go.
 - If we consistently miss the dates we commit to, no one will trust us.
 - Overtime is cheating—working extra hours is just a sneaky way of missing a date we've committed to.

--- a/technology-principles.md
+++ b/technology-principles.md
@@ -46,4 +46,5 @@ Time is the most precious resource we have. This applies at the organizational l
 - If commitments don't have a "by when" date, they won't happen.
 - If we never miss a date we've committed to, we’ll never know how fast we can go.
 - If we consistently miss the dates we commit to, no one will trust us.
+- As soon as you learn something that makes your current commitment invalid, make a new commitment.
 - Overtime is cheating—working extra hours is just a sneaky way of missing a date we've committed to.


### PR DESCRIPTION
I've update the supporting principles of Honour time. In general, these are just wording tweaks. I've chosen to make the language more "commitment-centric" as opposed to using terms like "deadline" and "timeline". 

I deleted `Time spent _not working at all_ makes us more effective during the time we spend working.` as I believe it's made redundant by `overtime is cheating`.

I added `If commitments don't have a "by when" date, they won't happen.`. To nudge our culture into a constant practice of talking about the future in more concrete terms. There's the escape valve of `If we never miss a date we've committed to, we’ll never know how fast we can go.` to nudge them away from the fear of "if I set that deadline I have to hit it"