### PR TITLE
Remove link to non-existent assertions-and-assessments.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This is a scrappy, default open resource. We're releasing this imperfect early v
   - [Technology Principles](technology-principles.md)
   - [Competencies by role (public)](https://docs.google.com/spreadsheets/d/1rV2q8TJaY8gHhuAhXaHBLJdld3XLdJG-UbL706SkCAY/edit#gid=221997572)
 - Core Skills
-  - [Inspiring Change](assertions-and-assessments.md)
   - [Culture and Principles](culture-and-principles.md)
 - Guides
   - [How we're organized](how-were-organized.md)


### PR DESCRIPTION
The `asssertions-and-assessments.md` page was removed in https://github.com/BenchLabs/bench-technology-handbook/commit/44368a39709068e340b08bfbcf45fd33f294ee87 but it was not removed from the TOC. This results in a dead link (404).

This removes the dead link.